### PR TITLE
SvgUtils: add namespace-aware filtering functions

### DIFF
--- a/SvgUtils.py
+++ b/SvgUtils.py
@@ -1,10 +1,12 @@
 import xml.etree.ElementTree as ET
 
+
 def get_id(root: ET.Element):
     """ Returns the id member of root. Asserts if not present."""
     id = root.get("id")
     assert(id)
     return id
+
 
 def _filter(root: ET.Element, predicate):
     """ Filter the direct children of root according to a predicate."""
@@ -19,3 +21,16 @@ def _filter_tag(root: ET.Element, tag):
     """
 
     return _filter(root, lambda x: x.tag == tag)
+
+
+_svg_namespace = '{http://www.w3.org/2000/svg}'
+_group_tag = _svg_namespace + 'g'
+_path_tag = _svg_namespace + 'path'
+
+
+def svg_groups(root: ET.Element):
+    return _filter_tag(root, _group_tag)
+
+
+def svg_paths(root: ET.Element):
+    return _filter_tag(root, _path_tag)

--- a/test_SvgUtils.py
+++ b/test_SvgUtils.py
@@ -34,7 +34,7 @@ class Input2:
         tester.assertEqual(len(groups), 0)
 
 
-class TestStringMethods(unittest.TestCase):
+class TestFilterMethods(unittest.TestCase):
 
     def test_get_id(self):
         with self.assertRaises(AssertionError):
@@ -53,6 +53,58 @@ class TestStringMethods(unittest.TestCase):
         Input1.inspect_groups(groups, self)
         groups = Svg._filter_tag(Input2.root, 'g')
         Input2.inspect_groups(groups, self)
+
+
+class Input3:
+    root = ET.fromstring('''
+      <svg
+         xmlns="http://www.w3.org/2000/svg"
+         xmlns:svg="http://www.w3.org/2000/svg">
+        <g id="group0">
+          <path id="path0_0" />
+        </g>
+        <g id="group1">
+          <path id="path1_0" />
+          <path id="path1_1" />
+        </g>
+      </svg>
+      ''')
+
+    def inspect_groups(groups, tester: unittest.TestCase):
+        tester.assertEqual(len(groups), 2)
+        tester.assertEqual(Svg.get_id(groups[0]), "group0")
+        tester.assertEqual(Svg.get_id(groups[1]), "group1")
+        tester.assertEqual(Svg.get_id(groups[0][0]), "path0_0")
+        tester.assertEqual(Svg.get_id(groups[1][0]), "path1_0")
+        tester.assertEqual(Svg.get_id(groups[1][1]), "path1_1")
+
+    def inspect_paths_root(paths, tester: unittest.TestCase):
+        tester.assertEqual(len(paths), 0)
+
+    def inspect_paths_group0(paths, tester: unittest.TestCase):
+        tester.assertEqual(len(paths), 1)
+        tester.assertEqual(Svg.get_id(paths[0]), "path0_0")
+
+    def inspect_paths_group1(paths, tester: unittest.TestCase):
+        tester.assertEqual(len(paths), 2)
+        tester.assertEqual(Svg.get_id(paths[0]), "path1_0")
+        tester.assertEqual(Svg.get_id(paths[1]), "path1_1")
+
+
+class TestSvgMethods(unittest.TestCase):
+
+    def test_svg_groups(self):
+        groups = Svg.svg_groups(Input3.root)
+        Input3.inspect_groups(groups, self)
+
+    def test_svg_paths(self):
+        paths_root = Svg.svg_paths(Input3.root)
+        groups = Svg.svg_groups(Input3.root)
+        paths_g0 = Svg.svg_paths(groups[0])
+        paths_g1 = Svg.svg_paths(groups[1])
+        Input3.inspect_paths_root(paths_root, self)
+        Input3.inspect_paths_group0(paths_g0, self)
+        Input3.inspect_paths_group1(paths_g1, self)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add helper functions that can operate on xml svg data containing the
usual svg namespace. That is, the entry name of svg nodes is always
prefixed by a huge namespace + the entry itself, for instance:

`http://www.w3.org/2000/svg:path`

Would be the tag of the "path" entry.

This patch adds functions for retrieving paths and groups that are
direct children of a given xml node.