### PR TITLE
JsAnimator: fix repeated test name

### DIFF
--- a/test_SvgJsAnimator.py
+++ b/test_SvgJsAnimator.py
@@ -26,7 +26,7 @@ class TestSvgJsPath(unittest.TestCase):
         with self.assertRaises(AssertionError):
           SvgJsAnimator.SvgJsPath(root, out)
 
-    def test_invalid_init_not_path(self):
+    def test_invalid_init_no_id(self):
         out = io.StringIO()
         with self.assertRaises(AssertionError):
           SvgJsAnimator.SvgJsPath(path_no_id, out)


### PR DESCRIPTION
Two tests had the same name, causing one of them to not run, as ir
overrides the definition of the first test.