### PR TITLE
JsAnimator: implement instant camera event

### DIFF
--- a/SvgUtils.py
+++ b/SvgUtils.py
@@ -26,6 +26,7 @@ def _filter_tag(root: ET.Element, tag):
 _svg_namespace = '{http://www.w3.org/2000/svg}'
 _group_tag = _svg_namespace + 'g'
 _path_tag = _svg_namespace + 'path'
+_rectangle_tag = _svg_namespace + 'rect'
 _svg_tag = _svg_namespace + 'svg'
 
 
@@ -35,3 +36,7 @@ def svg_groups(root: ET.Element):
 
 def svg_paths(root: ET.Element):
     return _filter_tag(root, _path_tag)
+
+
+def svg_rectangles(root: ET.Element):
+    return _filter_tag(root, _rectangle_tag)

--- a/example.py
+++ b/example.py
@@ -1,5 +1,5 @@
 from HtmlUtils import HtmlPrinter
-from SvgUtils import svg_groups
+import SvgUtils
 from SvgJsAnimator import SvgJsAnimator, SvgJsGroup
 import xml.etree.ElementTree as ET
 
@@ -12,8 +12,10 @@ with html.js_ctx():
     root = ET.parse('example.svg').getroot()
     animator = SvgJsAnimator(html.file, root)
     groups_to_draw = [SvgJsGroup(group, html.file)
-                      for group in svg_groups(root)]
+                      for group in SvgUtils.svg_groups(root)]
     [(animator.add_group_to_queue(group), animator.add_stop_event_to_queue())
      for group in groups_to_draw]
+    camera_events = SvgUtils.svg_rectangles(root)
+    animator.add_camera_event_to_queue(camera_events[0])
     animator.clear_paths_from_screen()
     animator.start_animation()

--- a/example.svg
+++ b/example.svg
@@ -2915,10 +2915,6 @@
        stroke-linejoin="round"
        d="m 192.304,903.622 q 0.15,-0.096 5.604,-3.02 5.453,-2.924 8.873,-4.855 3.421,-1.932 5.259,-2.989 1.839,-1.058 3.138,-1.722 1.299,-0.665 3.113,-1.729 1.814,-1.065 5.143,-2.856 3.329,-1.791 5.898,-2.911 2.57,-1.121 3.537,-1.56" />
   </g>
-  <g
-     id="g4418"
-     transform="translate(-1027.7206,79.242154)"
-     inkscape:groupmode="layer" />
   <rect
      style="fill:none;stroke:#000000;stroke-width:2.3375;stroke-miterlimit:4;stroke-dasharray:2.3375, 2.3375;stroke-dashoffset:17.0637;stroke-opacity:1"
      id="rectangle"

--- a/test_SvgJsAnimator.py
+++ b/test_SvgJsAnimator.py
@@ -20,6 +20,11 @@ root = ET.fromstring('''
     <path id="path11" />
   </g>
 
+  <rect id="rect1"
+    x="1"
+    y="2"
+    width="3"
+    height="4"/>
 </svg>
 ''')
 
@@ -172,6 +177,17 @@ class TestSvgJsAnimator(unittest.TestCase):
             out_str,
             f'''let (?P<bbox>.*) = {animator.js_svg_root}.getBBox\(\);
 .*{animator.js_foo_set_camera}\(\[(?P=bbox)''')
+
+    def test_add_camera_event_to_queue(self):
+        out = io.StringIO()
+        animator = SvgJsAnimator.SvgJsAnimator(out, root)
+        animator.add_camera_event_to_queue(SvgUtils.svg_rectangles(root)[0])
+        out_str = out.getvalue()
+        self.assertIn(
+            f'{animator.js_animation_queue}.push({{ '
+            f'{animator.js_kind_event} : {animator.js_kind_camera}, '
+            f'{animator.js_event_obj} : [1, 2, 3, 4] }})',
+            out_str)
 
 
 if __name__ == '__main__':

--- a/test_SvgUtils.py
+++ b/test_SvgUtils.py
@@ -67,6 +67,11 @@ class Input3:
           <path id="path1_0" />
           <path id="path1_1" />
         </g>
+        <rect id="rect1"
+          width="8"
+          height="8"
+          x="8"
+          y="8"/>
       </svg>
       ''')
 
@@ -90,6 +95,10 @@ class Input3:
         tester.assertEqual(Svg.get_id(paths[0]), "path1_0")
         tester.assertEqual(Svg.get_id(paths[1]), "path1_1")
 
+    def inspect_rectangles(rectangles, tester: unittest.TestCase):
+        tester.assertEqual(len(rectangles), 1)
+        tester.assertEqual(Svg.get_id(rectangles[0]), "rect1")
+
 
 class TestSvgMethods(unittest.TestCase):
 
@@ -102,9 +111,11 @@ class TestSvgMethods(unittest.TestCase):
         groups = Svg.svg_groups(Input3.root)
         paths_g0 = Svg.svg_paths(groups[0])
         paths_g1 = Svg.svg_paths(groups[1])
+        rectangles = Svg.svg_rectangles(Input3.root)
         Input3.inspect_paths_root(paths_root, self)
         Input3.inspect_paths_group0(paths_g0, self)
         Input3.inspect_paths_group1(paths_g1, self)
+        Input3.inspect_rectangles(rectangles, self)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch brings support for events that instantaneously change the camera to
that of an input rectangle. It does not provide a smooth animation yet, which
will be the subject of a future patch.