### PR TITLE
SvgVisitors: declare JS classes in ctor

### DIFF
--- a/CameraEvent.py
+++ b/CameraEvent.py
@@ -63,4 +63,4 @@ class CameraEvent:
 
     def gen_unique_name():
         CameraEvent.gid += 1
-        return 'p' + str(CameraEvent.gid)
+        return '_cam' + str(CameraEvent.gid)

--- a/SvgJsAnimator.py
+++ b/SvgJsAnimator.py
@@ -1,9 +1,5 @@
 import xml.etree.ElementTree as ET
 import SvgUtils
-from CameraEvent import CameraEvent
-from SequentialEventContainer import SequentialEventContainer
-from ParallelEventContainer import ParallelEventContainer
-from PathEvent import PathEvent
 
 
 class SvgJsAnimator:
@@ -45,12 +41,6 @@ class SvgJsAnimator:
 
         # Reset root dimensions to 100% so that BBox setting works properly.
         self.set_dimensions_to_100pc()
-
-        # Print all JS classes
-        ParallelEventContainer.print_js_class(self.out)
-        SequentialEventContainer.print_js_class(self.out)
-        PathEvent.print_js_class(self.out)
-        CameraEvent.print_js_class(self.out)
 
         self.js_event_idx = 'event_idx'
         self.js_event_list = 'event_list'

--- a/SvgVisitors.py
+++ b/SvgVisitors.py
@@ -29,10 +29,17 @@ class SimpleVisitor:
     """
 
     def __init__(self, out):
-        """Creates the visitor and use `out` to instantiate each of the Events."""
+        """Creates the visitor and use `out` to instantiate each of the Events.
+
+        A definition of the Event classes is added to `out`.
+        """
 
         self.out = out
         self.cameras = []
+        ParallelEventContainer.print_js_class(self.out)
+        SequentialEventContainer.print_js_class(self.out)
+        PathEvent.print_js_class(self.out)
+        CameraEvent.print_js_class(self.out)
 
     def visit_root(self, node: ET.ElementTree):
         """Create the Event graph, and return it as an array of Events."""

--- a/test_SvgVisitors.py
+++ b/test_SvgVisitors.py
@@ -22,6 +22,12 @@ class TestSimpleVisitor(unittest.TestCase):
         events = visitor.visit_root(TestSimpleVisitor.empty_root)
         self.assertEqual(len(events), 0)
 
+        out = out.getvalue()
+        self.assertIn('class CameraEvent', out)
+        self.assertIn('class ParallelEventContainer', out)
+        self.assertIn('class PathEvent', out)
+        self.assertIn('class SequentialEventContainer', out)
+
     flat_root = ET.fromstring('''
       <svg
          xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Since these visitos rely on the definition of Event classes, they should
declare such classes inside the `out` buffer.