### PR TITLE
events: add option for instant finish

### DIFF
--- a/svganimator/CameraEvent.py
+++ b/svganimator/CameraEvent.py
@@ -45,12 +45,14 @@ class CameraEvent:
                 this.root = root;
               }}
 
-              process_event(elapsed) {{
+              process_event(elapsed, finish_requested) {{
                 if (this.duration === 0) {{
                   this.root.setAttribute("viewBox", this.new_cam.join(" "));
                   return true;
                 }}
-                const progress = Math.min(1, elapsed / this.duration);
+                let progress = Math.min(1, elapsed / this.duration);
+                if (finish_requested)
+                  progress = 1
                 const total_delta = this.new_cam.map((n, idx) => n - this.old_cam[idx]);
                 const cam = this.old_cam.map((n, idx) => n + progress * total_delta[idx])
                 this.root.setAttribute("viewBox", cam.join(" "));

--- a/svganimator/ParallelEventContainer.py
+++ b/svganimator/ParallelEventContainer.py
@@ -34,7 +34,7 @@ class ParallelEventContainer:
                 this.base_elapsed = undefined;
               }}
 
-              process_event(elapsed) {{
+              process_event(elapsed, finish_requested) {{
                 if (this.base_elapsed === undefined)
                   this.base_elapsed = elapsed;
 
@@ -42,7 +42,7 @@ class ParallelEventContainer:
 
                 this.events.forEach((event, idx) => {{
                   if (!this.status[idx])
-                    this.status[idx] = event.process_event(event_elapsed);
+                    this.status[idx] = event.process_event(event_elapsed, finish_requested);
                 }});
 
                 return this.status.reduce((prev, curr) => prev && curr);

--- a/svganimator/PathEvent.py
+++ b/svganimator/PathEvent.py
@@ -35,9 +35,11 @@ class PathEvent:
 
               // Draws paths on the screen based on time elapsed and draw speed.
               // Returns true if the path has been drawn entirely.
-              process_event(elapsed) {{
+              process_event(elapsed, finish_requested) {{
                 const percentage = elapsed/this.total_time;
-                const progress = Math.min(1, percentage);
+                let progress = Math.min(1, percentage);
+                if (finish_requested)
+                  progress = 1
                 this.path.style.strokeDashoffset = Math.floor(this.length * (1 - progress));
                 return progress === 1;
               }}

--- a/svganimator/SequentialEventContainer.py
+++ b/svganimator/SequentialEventContainer.py
@@ -34,15 +34,22 @@ class SequentialEventContainer:
                 this.idx = 0;
               }}
 
-              process_event(elapsed) {{
+              process_event(elapsed, finish_requested) {{
                 if (this.base_elapsed === undefined)
                   this.base_elapsed = elapsed;
 
                 if (this.idx < this.events.length) {{
                   const event_elapsed = elapsed - this.base_elapsed;
-                  const finished = this.events[this.idx].process_event(event_elapsed);
+                  const finished = this.events[this.idx].process_event(event_elapsed, finish_requested);
                   if (finished) {{
                     this.base_elapsed = undefined;
+                    this.idx++
+                  }}
+                }}
+
+                if (finish_requested) {{
+                  while(this.idx < this.events.length) {{
+                    this.events[this.idx].process_event(0, finish_requested);
                     this.idx++
                   }}
                 }}

--- a/tests/test_CameraEvent.py
+++ b/tests/test_CameraEvent.py
@@ -84,7 +84,7 @@ class TestCameraEvent(unittest.TestCase):
 
         self.assertIn('class CameraEvent', out)
         self.assertIn('constructor(old_cam, new_cam, duration, root) {', out)
-        self.assertIn('process_event(elapsed)', out)
+        self.assertIn('process_event(elapsed, finish_requested)', out)
         self.assertIn('undo()', out)
 
 

--- a/tests/test_ParallelEventContainer.py
+++ b/tests/test_ParallelEventContainer.py
@@ -36,7 +36,7 @@ class TestParallelEventContainer(unittest.TestCase):
         buff = buff.getvalue()
         self.assertIn('class ParallelEventContainer', buff)
         self.assertIn('constructor(events)', buff)
-        self.assertIn('process_event(elapsed)', buff)
+        self.assertIn('process_event(elapsed, finish_requested)', buff)
         self.assertIn('undo()', buff)
 
 

--- a/tests/test_PathEvent.py
+++ b/tests/test_PathEvent.py
@@ -31,7 +31,7 @@ class TestPathEvent(unittest.TestCase):
         out = buff.getvalue()
         self.assertIn('class PathEvent', out)
         self.assertIn('constructor(path)', out)
-        self.assertIn('process_event(elapsed)', out)
+        self.assertIn('process_event(elapsed, finish_requested)', out)
         self.assertIn('clear_from_screen()', out)
         self.assertIn('undo()', out)
 

--- a/tests/test_SequentialEventContainer.py
+++ b/tests/test_SequentialEventContainer.py
@@ -36,7 +36,7 @@ class TestSequentialEventContainer(unittest.TestCase):
         buff = buff.getvalue()
         self.assertIn('class SequentialEventContainer', buff)
         self.assertIn('constructor(events)', buff)
-        self.assertIn('process_event(elapsed)', buff)
+        self.assertIn('process_event(elapsed, finish_requested)', buff)
         self.assertIn('undo()', buff)
 
 


### PR DESCRIPTION
This adds a parameter to the "process_event" functions requesting them to
finish processing th event. This allows users to skip animations.