### PR TITLE
sequential_container: use reverse order for undo

### DIFF
--- a/svganimator/SequentialEventContainer.py
+++ b/svganimator/SequentialEventContainer.py
@@ -60,7 +60,8 @@ class SequentialEventContainer:
               undo() {{
                 this.base_elapsed = undefined;
                 this.idx = 0;
-                this.events.forEach(e => e.undo());
+                // forEach can't iterate backwards, so use reduceRight.
+                this.events.reduceRight((_, e) => e.undo(), null);
               }}
             }}''', file=out)
 


### PR DESCRIPTION
Events that change global properties must be undone in reverse order, e.g., two
camera movements.