### PR TITLE
visitor: implement visit for circle objects

### DIFF
--- a/svganimator/CircleEvent.py
+++ b/svganimator/CircleEvent.py
@@ -1,0 +1,65 @@
+from svganimator import SvgUtils
+import xml.etree.ElementTree as ET
+
+
+class CircleEvent:
+    """Class to create a circle animation.
+
+    Manipulates the opacity property of circles in order to create the illusion
+    of a circle drawing itself.
+
+    The time taken to reach full opacity is proportional to the perimeter.
+    """
+
+    def __init__(self, node: ET.Element, out):
+        """Creates a CircleEvent from an SVG Circle node.
+
+        Note that process_event takes as an argument the number of milliseconds
+        elapsed since this event began.
+        """
+
+        assert SvgUtils.is_circle(node)
+
+        html_id = SvgUtils.get_id(node)
+        js_query = f'document.getElementById("{html_id}")'
+        self.js_name = CircleEvent.gen_unique_name()
+        print(f'let {self.js_name} = new CircleEvent({js_query})', file=out)
+        print(f'{self.js_name}.clear_from_screen()', file=out)
+
+    def print_js_class(out):
+        print(f'''
+            class CircleEvent {{
+              constructor(circle) {{
+                this.circle = circle;
+                this.total_time = circle.getTotalLength() / {CircleEvent.circle_speed};
+              }}
+
+              // Draws circles on the screen based on time elapsed and draw speed.
+              // Returns true if the circle has been drawn entirely.
+              process_event(elapsed, finish_requested) {{
+                const percentage = elapsed/this.total_time;
+                let progress = Math.min(1, percentage);
+                if (finish_requested)
+                  progress = 1
+                this.circle.style.opacity = progress;
+                return progress === 1;
+              }}
+
+              // Clears the circle from screen
+              clear_from_screen() {{
+                this.circle.style.opacity = 0;
+              }}
+
+              undo() {{
+                this.clear_from_screen();
+              }}
+            }}''', file=out)
+
+    gid = -1
+
+    def gen_unique_name():
+        CircleEvent.gid += 1
+        return '_circle' + str(CircleEvent.gid)
+
+    # TODO: make this a circle paremeter.
+    circle_speed = 0.4

--- a/svganimator/SvgUtils.py
+++ b/svganimator/SvgUtils.py
@@ -26,6 +26,7 @@ def filter_tag(root: ET.Element, tag):
 
 
 svg_namespace = '{http://www.w3.org/2000/svg}'
+circle_tag = svg_namespace + 'circle'
 group_tag = svg_namespace + 'g'
 path_tag = svg_namespace + 'path'
 rectangle_tag = svg_namespace + 'rect'
@@ -35,6 +36,12 @@ svg_tag = svg_namespace + 'svg'
 def svg_elements_named(name: str, root: ET.Element):
     """Returns direct children of `root` with a given id."""
     return filter(root, lambda x: get_id(x) == name)
+
+
+def is_circle(root: ET.Element):
+    """Returns true if root is an SVG circle."""
+
+    return root.tag == circle_tag
 
 
 def is_group(root: ET.Element):
@@ -59,6 +66,12 @@ def is_rectangle(root: ET.Element):
     """Returns true if root is an SVG rectangle."""
 
     return root.tag == rectangle_tag
+
+
+def svg_circles(root: ET.Element):
+    """Returns direct children of root that are SVG circles."""
+
+    return filter_tag(root, circle_tag)
 
 
 def svg_groups(root: ET.Element):

--- a/svganimator/SvgVisitors.py
+++ b/svganimator/SvgVisitors.py
@@ -2,6 +2,7 @@ from svganimator import SvgUtils
 from svganimator.CameraEvent import CameraEvent
 from svganimator.ParallelEventContainer import ParallelEventContainer
 from svganimator.PathEvent import PathEvent
+from svganimator.CircleEvent import CircleEvent
 from svganimator.SequentialEventContainer import SequentialEventContainer
 import xml.etree.ElementTree as ET
 import re
@@ -42,6 +43,7 @@ class SimpleVisitor:
         SequentialEventContainer.print_js_class(self.out)
         PathEvent.print_js_class(self.out)
         CameraEvent.print_js_class(self.out)
+        CircleEvent.print_js_class(self.out)
 
     def visit_root(self, node: ET.ElementTree):
         """Create the Event graph, and return it as an array of Events."""
@@ -54,6 +56,8 @@ class SimpleVisitor:
         return events
 
     def _visit(self, node: ET.ElementTree):
+        if SvgUtils.is_circle(node):
+            return self._visit_circle(node)
         if SvgUtils.is_path(node):
             return self._visit_path(node)
         if SvgUtils.is_group(node):
@@ -64,6 +68,9 @@ class SimpleVisitor:
             f'Warning: ignroring SVG node: {SvgUtils.get_id(node)}, '
             f'type = {node.tag}')
         return None
+
+    def _visit_circle(self, node: ET.ElementTree):
+        return CircleEvent(node, self.out)
 
     def _visit_path(self, node: ET.ElementTree):
         return PathEvent(node, self.out)

--- a/tests/test_CircleEvent.py
+++ b/tests/test_CircleEvent.py
@@ -1,0 +1,40 @@
+from svganimator import SvgUtils
+from svganimator.CircleEvent import CircleEvent
+import io
+import unittest
+import xml.etree.ElementTree as ET
+
+
+class TestCircleEvent(unittest.TestCase):
+    root = ET.fromstring('''
+      <svg
+         xmlns="http://www.w3.org/2000/svg"
+         xmlns:svg="http://www.w3.org/2000/svg"
+         id="root_id">
+         <circle id="circle0"/>
+      </svg>
+      ''')
+    circle = SvgUtils.svg_circles(root)[0]
+
+    def test_ctor(self):
+        buff = io.StringIO()
+        event = CircleEvent(TestCircleEvent.circle, buff)
+        self.assertIsNotNone(event.js_name)
+
+        out = buff.getvalue()
+        self.assertRegex(out, f'let {event.js_name} = new CircleEvent')
+        self.assertRegex(out, f'{event.js_name}.clear_from_screen()')
+
+    def test_print_class(self):
+        buff = io.StringIO()
+        CircleEvent.print_js_class(buff)
+        out = buff.getvalue()
+        self.assertIn('class CircleEvent', out)
+        self.assertIn('constructor(circle)', out)
+        self.assertIn('process_event(elapsed, finish_requested)', out)
+        self.assertIn('clear_from_screen()', out)
+        self.assertIn('undo()', out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_SvgUtils.py
+++ b/tests/test_SvgUtils.py
@@ -80,6 +80,7 @@ class Input3:
           height="8"
           x="8"
           y="8"/>
+        <circle id="circle1"/>
       </svg>
       ''')
 
@@ -106,6 +107,10 @@ class Input3:
     def inspect_rectangles(rectangles, tester: unittest.TestCase):
         tester.assertEqual(len(rectangles), 1)
         tester.assertEqual(Svg.get_id(rectangles[0]), "rect1")
+
+    def inspect_circles(circles, tester: unittest.TestCase):
+        tester.assertEqual(len(circles), 1)
+        tester.assertEqual(Svg.get_id(circles[0]), 'circle1')
 
 
 class TestSvgMethods(unittest.TestCase):
@@ -136,10 +141,15 @@ class TestSvgMethods(unittest.TestCase):
         for rectangle in rectangles:
             self.assertTrue(Svg.is_rectangle(rectangle))
 
+        circles = Svg.svg_circles(Input3.root)
+        for circle in circles:
+            self.assertTrue(Svg.is_circle(circle))
+
         Input3.inspect_paths_root(paths_root, self)
         Input3.inspect_paths_group0(paths_g0, self)
         Input3.inspect_paths_group1(paths_g1, self)
         Input3.inspect_rectangles(rectangles, self)
+        Input3.inspect_circles(circles, self)
 
 
 class TestHideNode(unittest.TestCase):


### PR DESCRIPTION
We use the alpha property, since the alternative would require animating
both the fill and outline.